### PR TITLE
Add Mocha as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express": "^4.17.1"
   },
   "devDependencies": {
+    "mocha": "6.2.2",
     "nodemon": "2.0.1"
   }
 }


### PR DESCRIPTION
Testing uses Mocha, but it is not listed as a dev dependency.